### PR TITLE
Implement ArrayAnalyzer and r2 metric

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ metrics = "metrics:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -1,2 +1,29 @@
+"""Public API for the metrics package."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+
+from .stats import ResidualStats
+from .analyzer.array import ArrayAnalyzer
+
+__all__ = ["ResidualStats", "analyze", "main", "ArrayAnalyzer"]
+
+
+def analyze(
+    y_pred: Iterable[float],
+    y_true: Iterable[float] | float | None = 0.0,
+    metrics: Iterable[str] | None = None,
+) -> ResidualStats:
+    """Return residual statistics for ``y_pred`` and ``y_true``."""
+
+    analyzer = ArrayAnalyzer(np.asarray(list(y_pred), dtype=float), y_true)
+    return analyzer.summary(metrics)
+
+
 def main() -> None:
+    """Entry point for ``python -m metrics``."""
+
     print("Hello from metrics!")

--- a/src/metrics/analyzer/array.py
+++ b/src/metrics/analyzer/array.py
@@ -1,0 +1,20 @@
+"""Analyzer for 1-D arrays."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .base import BaseAnalyzer
+
+
+class ArrayAnalyzer(BaseAnalyzer):
+    """Analyze vector residuals."""
+
+    def __init__(self, y_pred: np.ndarray, y_true: np.ndarray | float = 0.0) -> None:
+        y_pred = np.asarray(y_pred, dtype=float)
+        if np.isscalar(y_true):
+            y_true_arr = np.full_like(y_pred, float(y_true))
+        else:
+            y_true_arr = np.asarray(y_true, dtype=float)
+        residuals = y_pred - y_true_arr
+        super().__init__(residuals, y_true_arr, y_pred)

--- a/src/metrics/analyzer/base.py
+++ b/src/metrics/analyzer/base.py
@@ -1,0 +1,48 @@
+"""Base analyzer class for residual statistics."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable
+
+import numpy as np
+
+from ..metrics import METRICS
+from ..stats import ResidualStats
+
+
+class BaseAnalyzer:
+    """Prepare residuals and compute metric summaries."""
+
+    def __init__(
+        self,
+        residuals: np.ndarray,
+        y_true: np.ndarray | None = None,
+        y_pred: np.ndarray | None = None,
+    ) -> None:
+        self.res = np.asarray(residuals, dtype=float)
+        self.y_true = np.asarray(y_true, dtype=float) if y_true is not None else None
+        self.y_pred = np.asarray(y_pred, dtype=float) if y_pred is not None else None
+
+    def _run_metric(self, name: str) -> float:
+        fn = METRICS[name]
+        sig = inspect.signature(fn)
+        kwargs = {}
+        if "res" in sig.parameters:
+            kwargs["res"] = self.res
+        if "y_true" in sig.parameters and self.y_true is not None:
+            kwargs["y_true"] = self.y_true
+        if "y_pred" in sig.parameters and self.y_pred is not None:
+            kwargs["y_pred"] = self.y_pred
+        return fn(**kwargs)
+
+    def summary(self, metrics: Iterable[str] | None = None) -> ResidualStats:
+        base = {"rms", "bias", "std"}
+        wanted = base | set(metrics or ())
+        results = {m: self._run_metric(m) for m in wanted}
+        return ResidualStats(
+            rms=results["rms"],
+            bias=results["bias"],
+            std=results["std"],
+            r2=results.get("r2"),
+        )

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+
+METRICS: dict[str, Callable[..., float]] = {}
+
+
+def register_metric(
+    name: str,
+) -> Callable[[Callable[..., float]], Callable[..., float]]:
+    """Register *name* as a metric."""
+
+    def decorator(fn: Callable[..., float]) -> Callable[..., float]:
+        METRICS[name] = fn
+        return fn
+
+    return decorator
+
+
+@register_metric("rms")
+def rms(res: np.ndarray) -> float:
+    return np.sqrt(np.nanmean(res**2))
+
+
+@register_metric("bias")
+def bias(res: np.ndarray) -> float:
+    return np.nanmean(res)
+
+
+@register_metric("std")
+def std(res: np.ndarray) -> float:
+    return np.nanstd(res, ddof=0)
+
+
+@register_metric("r2")
+def r2(res: np.ndarray, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    """Return the coefficient of determination."""
+
+    ss_res = np.nansum((y_true - y_pred) ** 2)
+    ss_tot = np.nansum((y_true - np.nanmean(y_true)) ** 2)
+    if ss_tot == 0:
+        return np.nan
+    return 1.0 - ss_res / ss_tot

--- a/src/metrics/stats.py
+++ b/src/metrics/stats.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ResidualStats:
+    """Immutable container for common residual statistics."""
+
+    rms: float
+    bias: float
+    std: float
+    r2: Optional[float] = None
+    max: Optional[float] = None
+    min: Optional[float] = None
+    median: Optional[float] = None
+    p025: Optional[float] = None
+    p975: Optional[float] = None
+    ks_p: Optional[float] = None
+    ci_low: Optional[float] = None
+    ci_high: Optional[float] = None
+
+    def as_dict(self) -> dict[str, float | None]:
+        """Return statistics as a plain dictionary."""
+
+        return asdict(self)

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from metrics import analyze
+
+
+def test_analyze_basic() -> None:
+    residuals = np.array([1.0, -1.0, 2.0, -2.0])
+    stats = analyze(residuals)
+
+    np.testing.assert_allclose(stats.rms, np.sqrt(np.mean(residuals**2)))
+    np.testing.assert_allclose(stats.bias, np.mean(residuals))
+    np.testing.assert_allclose(stats.std, np.std(residuals, ddof=0))
+
+
+def test_analyze_with_true() -> None:
+    y_true = np.array([1.0, 2.0, 3.0])
+    y_pred = np.array([1.5, 1.5, 3.5])
+    stats = analyze(y_pred, y_true, metrics=("rms", "bias", "std", "r2"))
+
+    residuals = y_pred - y_true
+    np.testing.assert_allclose(stats.rms, np.sqrt(np.mean(residuals**2)))
+    np.testing.assert_allclose(stats.bias, np.mean(residuals))
+    np.testing.assert_allclose(stats.std, np.std(residuals, ddof=0))
+    from sklearn.metrics import r2_score
+
+    np.testing.assert_allclose(stats.r2, r2_score(y_true, y_pred))


### PR DESCRIPTION
## Summary
- create `analyzer` package with `BaseAnalyzer` and `ArrayAnalyzer`
- compute r2 internally without scikit-learn
- expand `analyze` to handle y_pred/y_true inputs
- test analyzing with and without true values

## Testing
- `ruff format src/metrics/analyzer/base.py src/metrics/metrics.py src/metrics/__init__.py tests/test_analyze.py`
- `ruff check .`
- `mypy src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6873b1353a30832babcd2b1f3c04f2bb