### PR TITLE
Implement MatrixAnalyzer

### DIFF
--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -9,9 +9,17 @@ import numpy as np
 from .stats import ResidualStats
 from .analyzer.array import ArrayAnalyzer
 from .analyzer.dataframe import DataFrameAnalyzer
+from .analyzer.matrix import MatrixAnalyzer
 import pandas as pd
 
-__all__ = ["ResidualStats", "analyze", "main", "ArrayAnalyzer", "DataFrameAnalyzer"]
+__all__ = [
+    "ResidualStats",
+    "analyze",
+    "main",
+    "ArrayAnalyzer",
+    "DataFrameAnalyzer",
+    "MatrixAnalyzer",
+]
 
 
 def analyze(
@@ -25,14 +33,14 @@ def analyze(
 ) -> pd.DataFrame | ResidualStats:
     """Return residual statistics for the given inputs."""
 
-    if isinstance(y_pred, pd.DataFrame) and pred_col and true_col:
-        return DataFrameAnalyzer(y_pred, pred_col, true_col).summary(
-            group=group, metrics=metrics
-        )
+    if isinstance(y_pred, pd.DataFrame):
+        if pred_col and true_col:
+            return DataFrameAnalyzer(y_pred, pred_col, true_col).summary(
+                group=group, metrics=metrics
+            )
+        return MatrixAnalyzer(y_pred).summary(group=group, metrics=metrics)
 
-    return ArrayAnalyzer(np.asarray(list(y_pred), dtype=float), y_true).summary(
-        metrics
-    )
+    return ArrayAnalyzer(np.asarray(list(y_pred), dtype=float), y_true).summary(metrics)
 
 
 def main() -> None:

--- a/src/metrics/analyzer/matrix.py
+++ b/src/metrics/analyzer/matrix.py
@@ -1,0 +1,53 @@
+"""Analyzer for 2-D matrices with time index and site columns."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import cast
+
+import pandas as pd
+
+from .. import grouping
+from ..metrics import METRICS
+from .base import BaseAnalyzer
+
+
+class MatrixAnalyzer(BaseAnalyzer):
+    """Analyze residual matrices (time rows, site columns)."""
+
+    def __init__(self, mat: pd.DataFrame) -> None:
+        self.mat = mat
+        super().__init__(mat.to_numpy().ravel())
+
+    def summary(  # type: ignore[override]
+        self,
+        group: str | list[str] | None = "total",
+        metrics: Iterable[str] | None = None,
+    ) -> pd.DataFrame:
+        if group in (None, "total"):
+            stats = super().summary(metrics)
+            return pd.DataFrame([stats.as_dict()])
+
+        if isinstance(group, str):
+            group_list = [group]
+        else:
+            group_list = list(cast(Iterable[str], group))
+
+        long = (
+            self.mat.stack().rename_axis(["time", "site"]).rename("res").reset_index()
+        )
+        group_keys: list[pd.Series] = []
+        for g in group_list:
+            if g == "site":
+                group_keys.append(long["site"])
+            elif g.startswith("time:"):
+                rule = g.split(":", 1)[1]
+                group_keys.append(grouping.make_time_grouper(long["time"], rule))
+            else:
+                raise KeyError(f"unsupported group {g}")
+
+        base = {"rms", "bias", "std"}
+        wanted = base | set(metrics or ())
+        agg_funcs = {name: METRICS[name] for name in wanted}
+        result = long.groupby(group_keys)["res"].agg(agg_funcs)
+        return result.reset_index()

--- a/tests/test_matrix_analyzer.py
+++ b/tests/test_matrix_analyzer.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+from metrics.analyzer.matrix import MatrixAnalyzer
+
+
+def make_matrix() -> pd.DataFrame:
+    data = {
+        "a": [1.0, 2.0, 3.0, 4.0],
+        "b": [1.5, 2.5, 3.5, 4.5],
+    }
+    idx = pd.date_range("2024-01-01", periods=4, freq="H")
+    return pd.DataFrame(data, index=idx)
+
+
+def test_matrix_summary_total() -> None:
+    mat = make_matrix()
+    analyzer = MatrixAnalyzer(mat)
+    out = analyzer.summary()
+    assert set(out.columns) >= {"rms", "bias", "std"}
+
+
+def test_matrix_summary_group() -> None:
+    mat = make_matrix()
+    analyzer = MatrixAnalyzer(mat)
+    out = analyzer.summary(group=["site", "time:H"], metrics=("rms",))
+    assert "site" in out.columns
+    assert "rms" in out.columns


### PR DESCRIPTION
## Summary
- add `MatrixAnalyzer` for 2-D residual matrices
- route `analyze` to `MatrixAnalyzer` for data frames without column names
- export new analyzer in package `__all__`
- test `MatrixAnalyzer` functionality

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68747539b1d4832ba431c56b97feb4f1